### PR TITLE
Proper Use Name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ___
 ```php
 // in App\Nova\User
 ...
-use signifly\Nova\Fields\ProgressBar\ProgressBar;
+use Signifly\Nova\Fields\ProgressBar\ProgressBar;
 ...
 
 /**


### PR DESCRIPTION
Fixes error where class is not found